### PR TITLE
feat: refine homepage layout and news cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+npm-debug.log*
+yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -16,11 +16,10 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.12",
-      "postcss": "^8.4.16",
-  "tailwindcss": "^3.2.4",
-  "@vitejs/plugin-react": "^4.0.0",
-  "vite": "^4.3.9",
-  "typescript": "^5.0.4"
-   
+    "postcss": "^8.4.16",
+    "tailwindcss": "^3.2.4",
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.3.9",
+    "typescript": "^5.0.4"
   }
 }

--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -9,11 +9,19 @@ export interface Post {
 
 const NewsCard: React.FC<{ post: Post }> = ({ post }) => {
   return (
-    <article className="rounded-xl overflow-hidden shadow-md">
-      <img src={post.image} alt={post.title} className="w-full h-40 object-cover" />
-      <div className="bg-primary px-4 py-2">
-        <p className="text-white text-sm opacity-80">{post.tag} • {post.time}</p>
-        <h3 className="text-white font-semibold">{post.title}</h3>
+    <article className="bg-white rounded-xl overflow-hidden border shadow-sm flex flex-col">
+      <img
+        src={post.image}
+        alt={post.title}
+        className="w-full h-40 object-cover"
+      />
+      <div className="p-4 flex-1 flex flex-col">
+        <p className="text-xs text-gray-500 font-medium mb-2">
+          {post.tag} • {post.time}
+        </p>
+        <h3 className="text-primary font-semibold text-lg flex-1">
+          {post.title}
+        </h3>
       </div>
     </article>
   );

--- a/src/components/Ticker.tsx
+++ b/src/components/Ticker.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 const Ticker: React.FC = () => {
   return (
-    <div className="bg-gray-100 py-2 overflow-hidden">
-      <div className="animate-marquee whitespace-nowrap text-sm">
-        <span className="mx-4">IBOVESPA: 128.000,00 +0,5%</span>
+    <div className="bg-white border-y py-2 overflow-hidden">
+      <div className="animate-marquee whitespace-nowrap text-sm text-gray-700">
+        <span className="mx-4">BVM12: 1.352,7 +12,3%</span>
+        <span className="mx-4">IBOVESPA: 128.000 -0,5%</span>
         <span className="mx-4">DÓLAR: R$ 5,25 -0,2%</span>
-        <span className="mx-4">NASDAQ: 13.200,00 +0,8%</span>
-        <span className="mx-4">BITCOIN: $45.000,00 +2,0%</span>
+        <span className="mx-4">NASDAQ: 13.200 +0,8%</span>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,6 @@
   100% { transform: translateX(-100%); }
 }
 
-.marquee {
+.animate-marquee {
   animation: marquee 30s linear infinite;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,11 +26,43 @@ const posts: Post[] = [
 
 const Home: React.FC = () => {
   return (
-    <div className="space-y-8">
+    <div className="space-y-12">
+      <section className="bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4 py-12 flex flex-col lg:flex-row items-center gap-8">
+          <div className="flex-1 space-y-4 text-center lg:text-left">
+            <span className="text-sm font-semibold text-secondary tracking-wide uppercase">
+              Atualizações ESG
+            </span>
+            <h1 className="text-3xl md:text-4xl font-bold text-primary leading-tight">
+              Notícias, dados e visão do mercado verde
+            </h1>
+            <p className="text-gray-600 max-w-xl mx-auto lg:mx-0">
+              Acompanhe os principais movimentações de mercado ESG, índices proprietários e análises da BVM12 em um só lugar.
+            </p>
+          </div>
+          <div className="w-full max-w-sm bg-white shadow rounded-lg p-6">
+            <dl className="space-y-4">
+              <div className="flex justify-between">
+                <dt className="font-medium text-gray-600">BVM12</dt>
+                <dd className="text-right">
+                  <div className="text-lg font-semibold text-primary">1.352,7</div>
+                  <div className="text-sm text-green-600">+12,3%</div>
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="font-medium text-gray-600">ESG</dt>
+                <dd className="text-right">
+                  <div className="text-lg font-semibold text-primary">US$ 89,51</div>
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </section>
       <Ticker />
-      <section className="container mx-auto px-4 py-8">
-        <h2 className="text-2xl font-semibold mb-4">Notícias</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <section className="max-w-7xl mx-auto px-4 py-8">
+        <h2 className="text-2xl font-semibold mb-6 text-primary">Notícias</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {posts.map((post, index) => (
             <NewsCard key={index} post={post} />
           ))}


### PR DESCRIPTION
## Summary
- add hero section with ESG updates and metrics
- restyle ticker and news cards
- clean up project config and gitignore

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4672621f083249eca3a3ccbb73f8c